### PR TITLE
add abort signal to API

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,9 @@ The package is namespaced to `Waifuvault`, so to import it, simply:
 import Waifuvault from "waifuvault-node-api";
 ```
 
+Each function takes a optional `signal` from an abort controller as the last argument,
+you may use this to abort the requests
+
 ### Upload File<a id="upload-file"></a>
 
 To Upload a file, use the `uploadFile` function. This function takes the following options as an object:

--- a/src/typeings.ts
+++ b/src/typeings.ts
@@ -68,7 +68,7 @@ export type WaifuError = {
 /**
  * The response from the api for files and uploads
  */
-export type WaifuResponse<T extends string | number = string> = {
+export type WaifuResponse<T extends string | number = number> = {
     /**
      * The token for the uploaded file
      */


### PR DESCRIPTION
like the Go code, this now takes a abort signal, to allow requests to be aborted.

I suggest the Python and C# versions to also use similar logic if such thing exists 