### PR TITLE
Add badge to README

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,5 @@
+name: Test
+
 on:
   push:
     branches: [ "main" ]

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # waifuvault-node-api
 
+![tests](https://github.com/waifuvault/waifuVault-node-api/actions/workflows/main.yml/badge.svg)
+
 This contains the official API bindings for uploading, deleting and obtaining files
 with [waifuvault.moe](https://waifuvault.moe/). Contains a full up to date API for interacting with the service
 


### PR DESCRIPTION
- You can add a badge to the top of the `README` to display the result of the last GH Action to run.
- If you don't add a `name` to your `yml` file, the badge will use the name of the `yml` file, which is ugly, so I gave it a name as well.

I think this is a cool GH feature but I'm not offended if you think it's dumb
