### PR TITLE
Handle resolving paths starting with ~ to user home directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "waifuvault-node-api",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "waifuvault-node-api",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^8.57.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waifuvault-node-api",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Official Node API for waifuvault.moe",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/WaifuApi.ts
+++ b/src/WaifuApi.ts
@@ -10,6 +10,7 @@ import type {
 } from "./typeings.js";
 import fs from "node:fs/promises";
 import path from "node:path";
+import os from "node:os";
 
 const url = "https://waifuvault.moe";
 
@@ -34,7 +35,7 @@ export async function uploadFile(options: XOR<FileUpload, UrlUpload>, signal?: A
         if (file instanceof Buffer) {
             blob = new Blob([file]);
         } else {
-            blob = await createBlobFromFile(file!);
+            blob = await createBlobFromFile(expandHomedir(file!));
             if (!fileName) {
                 fileName = path.basename(file!);
             }
@@ -189,4 +190,8 @@ function getUrl(obj?: Record<string, unknown>, path?: string): string {
         return `${baseRestUrl}?${parsedParams}`;
     }
     return baseRestUrl;
+}
+
+function expandHomedir(filePath: string): string {
+    return filePath.startsWith("~") ? path.join(os.homedir(), filePath.slice(1)) : filePath;
 }


### PR DESCRIPTION
This makes it resolve filepaths for upload starting with ~ to the users home directory.
This is standard practice in Linux/Mac.

I did not bump the version number, only added the fix code, so you can review.